### PR TITLE
FIX: 이미지 링크 전송방식을 변경하였다

### DIFF
--- a/components/ProductSubmit/index.tsx
+++ b/components/ProductSubmit/index.tsx
@@ -53,7 +53,8 @@ const ProductSubmit = () => {
 		description: '',
 		price: 0,
 		carbon_emissions: 0,
-		is_eco_friendly: true
+		is_eco_friendly: true,
+		image_link: ['https://dl.dropbox.com/s/5r047c5fqiwbv8m/wrater.jpg']
 	});
 
 	const router = useRouter();
@@ -82,21 +83,17 @@ const ProductSubmit = () => {
 			mode: 'cors',
 			cache: 'no-cache',
 			credentials: 'same-origin',
-			body: JSON.stringify({...formValue, image_link: ['https://previews.123rf.com/images/baldyrgan/baldyrgan1309/baldyrgan130900283/22348504-%EA%B7%B8%EB%A6%B0-%EC%97%90%EC%BD%94-%EC%97%90%EB%84%88%EC%A7%80-%EA%B0%9C%EB%85%90-%EC%8B%9D%EB%AC%BC%EC%9D%80-%EC%A0%84%EA%B5%AC-%EC%95%88%EC%97%90-%EC%84%B1%EC%9E%A5.jpg']}), // data can be `string` or {object}!
+			body: JSON.stringify(formValue), // data can be `string` or {object}!
 			headers:{
-				'Content-Type': 'application/x-www-form-urlencoded'
+				'Content-Type': 'application/json'
 			},
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		}).then(res => res.json())
 			.then(response => {
-				console.log('Success:', JSON.stringify(response))
-				alert(`제품 등록 성공! ${JSON.stringify(response)}`);
 				router.back();
 			})
 			.catch(error => {
-				console.error('Error:', error);
-				alert(`제품 등록 실패! ${error}`);
 			});
 	}
 


### PR DESCRIPTION
- 원종님 전송할 때, 이미지 링크 보내는 방식을 변경해보는 것이 어떨까요? 기존 방식으로 전송하였을 떄 무슨 이유인지 모르겠는데 서버에서 제대로 반환값을 전송할 수 없었습니다.
- 그리고 포맷을 `application/json`으로 변경해보는 것도 나쁘지 않을 것 같습니다. 저번에 CORS 문제때문에 형식을 변경하셨다고 하셨는데 한번 이렇게 서버에 요청해보시고 안되면 다시 한번 해결해보겠습니다. 물론 로컬에서 한거랑 배포된 서버에 요청하는 거랑 다를 수 도 있다고 생각합니다.

https://user-images.githubusercontent.com/14002238/133447486-b41727f2-1f64-4cf9-8ddf-2de7c9e750b2.mov

